### PR TITLE
Fix markers when there's a token rotation

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,7 @@
 import OBR from "@owlbear-rodeo/sdk";
 import { getPluginId } from "./getPluginId";
+import { isImage, Math2 } from "@owlbear-rodeo/sdk";
+import type { Image } from "@owlbear-rodeo/sdk";
 
 import icon from "./icon.svg";
 
@@ -35,4 +37,124 @@ OBR.onReady(() => {
     },
     shortcut: "Shift + C"
   });
+
+  // Listen for token changes to fix marker transformations
+  OBR.scene.items.onChange(async (items) => {
+    // Find tokens that have changed
+    const changedTokens = items.filter((item): item is Image => 
+      isImage(item) && 
+      (item.layer === "CHARACTER" || item.layer === "MOUNT")
+    );
+
+    if (changedTokens.length === 0) return;
+
+    // Get all condition markers
+    const allItems = await OBR.scene.items.getItems();
+    const conditionMarkers = allItems.filter((item): item is Image => {
+      if (!isImage(item)) return false;
+      const metadata = item.metadata[getPluginId("metadata")];
+      return !!(metadata && typeof metadata === "object" && "enabled" in metadata && metadata.enabled);
+    });
+
+    // Get scene DPI
+    const sceneDpi = await OBR.scene.grid.getDpi();
+
+    // Find markers attached to changed tokens and calculate their correct transforms
+    const markersToUpdate: Array<{ 
+      id: string; 
+      position: { x: number; y: number }; 
+      rotation: number;
+      scale: { x: number; y: number };
+    }> = [];
+
+    for (const token of changedTokens) {
+      const attachedMarkers = conditionMarkers.filter(m => m.attachedTo === token.id);
+      
+      for (let i = 0; i < attachedMarkers.length; i++) {
+        const marker = attachedMarkers[i];
+        const newPosition = getMarkerPosition(token, i, sceneDpi);
+        const newScale = getMarkerScale(token);
+        
+        // Only update if something changed
+        if (
+          marker.position.x !== newPosition.x ||
+          marker.position.y !== newPosition.y ||
+          marker.rotation !== 0 ||
+          marker.scale.x !== newScale.x ||
+          marker.scale.y !== newScale.y
+        ) {
+          markersToUpdate.push({
+            id: marker.id,
+            position: newPosition,
+            rotation: 0,
+            scale: newScale
+          });
+        }
+      }
+    }
+
+    // Update markers if needed
+    if (markersToUpdate.length > 0) {
+      await OBR.scene.items.updateItems(
+        markersToUpdate.map(m => m.id),
+        (markers) => {
+          for (let i = 0; i < markers.length; i++) {
+            if (isImage(markers[i])) {
+              markers[i].position = markersToUpdate[i].position;
+              markers[i].scale = markersToUpdate[i].scale;
+              markers[i].rotation = 0;
+              markers[i].disableAttachmentBehavior = ["ROTATION", "SCALE"];
+            }
+          }
+        }
+      );
+    }
+  });
 });
+
+// Helper functions (duplicated from helpers.ts for background script)
+function getMarkerPosition(imageItem: Image, count: number, sceneDpi: number) {
+  const MARKERS_PER_ROW = 5;
+
+  // Find position with respect to image top left corner of image grid
+  const markerGridPosition = {
+    x: count % MARKERS_PER_ROW,
+    y: Math.floor(count / MARKERS_PER_ROW),
+  };
+  const gridCellSpacing = imageItem.image.width / MARKERS_PER_ROW;
+  let position = Math2.multiply(markerGridPosition, gridCellSpacing);
+
+  // Find position with respect to item position
+  position = Math2.subtract(position, imageItem.grid.offset);
+  position = Math2.multiply(position, sceneDpi / imageItem.grid.dpi);
+  
+  // Use absolute scale to avoid position mirroring when token is flipped
+  const absScale = {
+    x: Math.abs(imageItem.scale.x),
+    y: Math.abs(imageItem.scale.y),
+  };
+
+  position = {
+    x: position.x * absScale.x,
+    y: position.y * absScale.y
+  };
+
+  position = {
+    x: position.x + imageItem.position.x,
+    y: position.y + imageItem.position.y
+  };
+
+  return position;
+}
+
+function getMarkerScale(imageItem: Image) {
+  // Use absolute scale to prevent markers from being flipped
+  const scale = Math2.multiply(
+    {
+      x: Math.abs(imageItem.scale.x),
+      y: Math.abs(imageItem.scale.x), // x is intentional, x and y must match
+    },
+    imageItem.image.width / imageItem.grid.dpi
+  );
+  return scale;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -58,10 +58,10 @@ export async function buildConditionMarker(
 
   const builtMarker = buildImage(markerImage, imageGrid)
     .position(getMarkerPosition(attached, attachedCount, sceneDpi))
-    // Keep marker orientation fixed (do not inherit parent's rotation)
     .rotation(0)
     .scale(getMarkerScale(attached))
     .attachedTo(attached.id)
+    .disableAttachmentBehavior(["ROTATION"])
     .locked(true)
     .name(`Condition Marker - ${name}`)
     .metadata({ [getPluginId("metadata")]: { enabled: true } })
@@ -91,14 +91,7 @@ function getMarkerPosition(imageItem: Image, count: number, sceneDpi: number) {
   // Find position with respect to item position
   position = Math2.subtract(position, imageItem.grid.offset);
   position = Math2.multiply(position, sceneDpi / imageItem.grid.dpi); // scale switch from image to scene
-  // Apply absolute scale to avoid inheriting any mirroring from the parent
-  // (flipping the token should not mirror the marker image or offset).
-  const absScale = { x: Math.abs(imageItem.scale.x), y: Math.abs(imageItem.scale.x) };
-  position = Math2.multiply(position, absScale);
-  // Rotate the marker offset by the parent's rotation so markers stay
-  // anchored to the same relative position on the parent even when the
-  // parent is rotated. The marker image itself will remain unrotated
-  // (we force marker.rotation = 0 when creating/updating the marker).
+  position = Math2.multiply(position, imageItem.scale);
   position = Math2.rotate(position, { x: 0, y: 0 }, imageItem.rotation);
 
   // find position with respect to world
@@ -107,16 +100,23 @@ function getMarkerPosition(imageItem: Image, count: number, sceneDpi: number) {
   return position;
 }
 
-/**
- * Get number of grid cells that the parent items spans horizontally
- */
+ /**
+  * Get number of grid cells that the parent items spans horizontally
+  */
 function getMarkerScale(imageItem: Image) {
-  // Use absolute value of the parent's x scale to avoid mirroring the marker
-  const absScale = { x: Math.abs(imageItem.scale.x), y: Math.abs(imageItem.scale.x) };
-  const scale = Math2.multiply(absScale, imageItem.image.width / imageItem.grid.dpi);
+  const scale = Math2.multiply(
+    {
+      x: imageItem.scale.x,
+      y: imageItem.scale.x, // x is intentional, x and y must match
+    },
+    imageItem.image.width / imageItem.grid.dpi
+  );
   return scale;
 }
 
+/**
+ * Reposition markers after adding or removing conditions
+ */
 /**
  * Reposition a marker after one was deleted, always hug the upper left corner
  */
@@ -128,7 +128,7 @@ export async function repositionConditionMarker(imageItems: Image[]) {
   });
 
   let attachedMarkers: Image[] = [];
-  let newMarker: { id: string; position: Vector2; scale: { x: number; y: number } }[] = [];
+  let newMarker: { id: string; position: Vector2 }[] = [];
   for (const imageItem of imageItems) {
     // Find all markers attached to this item
     attachedMarkers = conditionMarkers.filter(
@@ -141,7 +141,6 @@ export async function repositionConditionMarker(imageItems: Image[]) {
       newMarker.push({
         id: attachedMarkers[i].id,
         position: getMarkerPosition(imageItem, i, sceneDpi),
-        scale: getMarkerScale(imageItem),
       });
     }
   }
@@ -151,14 +150,9 @@ export async function repositionConditionMarker(imageItems: Image[]) {
     newMarker.map(marker => marker.id),
     images => {
       for (let i = 0; i < images.length; i++) {
-        if (images[i].id !== newMarker[i].id) {
+        if (images[i].id !== newMarker[i].id)
           console.error("Condition marker ID mismatch, skipping item.");
-        } else {
-          images[i].position = newMarker[i].position;
-          // Ensure markers keep a fixed orientation and correct size when they are repositioned
-          images[i].rotation = 0;
-          images[i].scale = newMarker[i].scale;
-        }
+        else images[i].position = newMarker[i].position;
       }
     }
   );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -58,7 +58,8 @@ export async function buildConditionMarker(
 
   const builtMarker = buildImage(markerImage, imageGrid)
     .position(getMarkerPosition(attached, attachedCount, sceneDpi))
-    .rotation(attached.rotation)
+    // Keep marker orientation fixed (do not inherit parent's rotation)
+    .rotation(0)
     .scale(getMarkerScale(attached))
     .attachedTo(attached.id)
     .locked(true)
@@ -90,7 +91,14 @@ function getMarkerPosition(imageItem: Image, count: number, sceneDpi: number) {
   // Find position with respect to item position
   position = Math2.subtract(position, imageItem.grid.offset);
   position = Math2.multiply(position, sceneDpi / imageItem.grid.dpi); // scale switch from image to scene
-  position = Math2.multiply(position, imageItem.scale);
+  // Apply absolute scale to avoid inheriting any mirroring from the parent
+  // (flipping the token should not mirror the marker image or offset).
+  const absScale = { x: Math.abs(imageItem.scale.x), y: Math.abs(imageItem.scale.x) };
+  position = Math2.multiply(position, absScale);
+  // Rotate the marker offset by the parent's rotation so markers stay
+  // anchored to the same relative position on the parent even when the
+  // parent is rotated. The marker image itself will remain unrotated
+  // (we force marker.rotation = 0 when creating/updating the marker).
   position = Math2.rotate(position, { x: 0, y: 0 }, imageItem.rotation);
 
   // find position with respect to world
@@ -99,20 +107,16 @@ function getMarkerPosition(imageItem: Image, count: number, sceneDpi: number) {
   return position;
 }
 
- /**
-  * Get number of grid cells that the parent items spans horizontally
-  */
+/**
+ * Get number of grid cells that the parent items spans horizontally
+ */
 function getMarkerScale(imageItem: Image) {
-  const scale = Math2.multiply(
-    {
-      x: imageItem.scale.x,
-      y: imageItem.scale.x, // x is intentional, x and y must match
-    },
-    imageItem.image.width / imageItem.grid.dpi
-  );
+  // Use absolute value of the parent's x scale to avoid mirroring the marker
+  const absScale = { x: Math.abs(imageItem.scale.x), y: Math.abs(imageItem.scale.x) };
+  const scale = Math2.multiply(absScale, imageItem.image.width / imageItem.grid.dpi);
   return scale;
 }
- 
+
 /**
  * Reposition a marker after one was deleted, always hug the upper left corner
  */
@@ -124,7 +128,7 @@ export async function repositionConditionMarker(imageItems: Image[]) {
   });
 
   let attachedMarkers: Image[] = [];
-  let newMarker: { id: string; position: Vector2 }[] = [];
+  let newMarker: { id: string; position: Vector2; scale: { x: number; y: number } }[] = [];
   for (const imageItem of imageItems) {
     // Find all markers attached to this item
     attachedMarkers = conditionMarkers.filter(
@@ -137,6 +141,7 @@ export async function repositionConditionMarker(imageItems: Image[]) {
       newMarker.push({
         id: attachedMarkers[i].id,
         position: getMarkerPosition(imageItem, i, sceneDpi),
+        scale: getMarkerScale(imageItem),
       });
     }
   }
@@ -146,9 +151,14 @@ export async function repositionConditionMarker(imageItems: Image[]) {
     newMarker.map(marker => marker.id),
     images => {
       for (let i = 0; i < images.length; i++) {
-        if (images[i].id !== newMarker[i].id)
+        if (images[i].id !== newMarker[i].id) {
           console.error("Condition marker ID mismatch, skipping item.");
-        else images[i].position = newMarker[i].position;
+        } else {
+          images[i].position = newMarker[i].position;
+          // Ensure markers keep a fixed orientation and correct size when they are repositioned
+          images[i].rotation = 0;
+          images[i].scale = newMarker[i].scale;
+        }
       }
     }
   );


### PR DESCRIPTION
When the token does not have the original rotation, markers can flip.
<img width="656" height="703" alt="image" src="https://github.com/user-attachments/assets/e9f790ce-deed-49b9-8c1a-4468f3a7e773" />

This patch is not perfect, but when a marker is added, all the markers are rearanged on top left of the token with a neutral rotation.

<img width="649" height="525" alt="image" src="https://github.com/user-attachments/assets/c964e47f-a744-41dd-a98e-b4542bfbf2c1" />
